### PR TITLE
samples/bpf: fix build error due to incorrect linker flag

### DIFF
--- a/samples/bpf/Makefile
+++ b/samples/bpf/Makefile
@@ -209,7 +209,7 @@ TPROGS_CFLAGS += --sysroot=$(SYSROOT)
 TPROGS_LDFLAGS := -L$(SYSROOT)/usr/lib
 endif
 
-TPROGS_LDLIBS			+= $(LIBBPF) -lelf -lz
+TPROGS_LDLIBS			+= $(LIBBPF) -lelf -lz -lm
 TPROGLDLIBS_tracex4		+= -lrt
 TPROGLDLIBS_trace_output	+= -lrt
 TPROGLDLIBS_map_perf_test	+= -lrt


### PR DESCRIPTION
This might be important for the on-boarding task (since we are asking them to play around with the `samples/bpf` dir), therefore I'm opening a separate PR