### PR TITLE
Load larger progs

### DIFF
--- a/kernel/bpf/syscall.c
+++ b/kernel/bpf/syscall.c
@@ -2917,12 +2917,12 @@ static int bpf_prog_load_iu_base(union bpf_attr *attr, bpfptr_t uattr)
 		/*
 		 * Verify p_vaddr + p_filesz is within range.
 		 */
-		if (p_vaddr >= MAX_PROG_SZ)
-			goto error_phdr;
+		// if (p_vaddr >= MAX_PROG_SZ)
+		// 	goto error_phdr;
 		if (check_add_overflow(p_vaddr, p_filesz, &temp))
 			goto error_phdr;
-		if (temp > MAX_PROG_SZ)
-			goto error_phdr;
+		// if (temp > MAX_PROG_SZ)
+		// 	goto error_phdr;
 
 		/*
 		 * Compute p_vaddr_end = p_vaddr + p_memsz, aligned up to requested
@@ -2934,8 +2934,8 @@ static int bpf_prog_load_iu_base(union bpf_attr *attr, bpfptr_t uattr)
 			goto error_phdr;
 		if (align_up(p_vaddr_end, p_align, &p_vaddr_end))
 			goto error_phdr;
-		if (p_vaddr_end > MAX_PROG_SZ)
-			goto error_phdr;
+		// if (p_vaddr_end > MAX_PROG_SZ)
+		// 	goto error_phdr;
 
 		/* Enforce 4k alignment for now */
 		if (p_align != 1UL << PAGE_SHIFT)

--- a/kernel/bpf/syscall.c
+++ b/kernel/bpf/syscall.c
@@ -3007,8 +3007,20 @@ static int bpf_prog_load_iu_base(union bpf_attr *attr, bpfptr_t uattr)
 			goto error_vm;
 		}
 
-		memcpy(mem + offset + sec_off[ph_i], readbuf, p_filesz);
-		memset(mem + offset + p_filesz, 0, p_memsz - p_filesz);
+		// The general case shoud be:
+		//
+		//  |--zeros--|---segment----|--zeros--|
+		//   0000 0000 xxxx xxxx xxxx 0000 0000
+		//   |         |              |
+		//   |         |              mem + offset + sec_off[ph_i] + p_filesz
+		//   |         |
+		//   |         mem + offset + sec_off[ph_i]
+		//   |
+		//   mem + offset
+		//
+		memcpy(mem + offset + sec_off[ph_i],            readbuf, p_filesz          );
+		memset(mem + offset + sec_off[ph_i] + p_filesz, 0,       p_memsz - p_filesz);
+
 
 		// Set correct permission
 		page_cnt = (vm_size[ph_i] >> PAGE_SHIFT);

--- a/kernel/bpf/syscall.c
+++ b/kernel/bpf/syscall.c
@@ -2964,8 +2964,8 @@ static int bpf_prog_load_iu_base(union bpf_attr *attr, bpfptr_t uattr)
 		total_vm += vm_size[ph_i];
 	}
 
-	if (e_end != total_vm)
-		goto error_phdr;
+	// if (e_end != total_vm)
+	// 	goto error_phdr;
 
 	mem = __vmalloc(total_vm, GFP_KERNEL_ACCOUNT | __GFP_ZERO | GFP_USER);
 	if (!mem) {

--- a/kernel/bpf/syscall.c
+++ b/kernel/bpf/syscall.c
@@ -2684,7 +2684,7 @@ static int bpf_prog_load_iu_base(union bpf_attr *attr, bpfptr_t uattr)
 	Elf64_Half ph_i;
 	u64 addr_start = 0;
 	int *vm_size = NULL, *sec_off = NULL;
-	int total_vm = 0, offset, total_page = 0;
+	int total_vm = 0, offset, total_page = 0; // (TBD) Will `int' be enough in the future?
 
 	if (CHECK_ATTR(BPF_PROG_LOAD))
 		return -EINVAL;
@@ -2975,6 +2975,10 @@ static int bpf_prog_load_iu_base(union bpf_attr *attr, bpfptr_t uattr)
 	prog->mem.mem = mem;
 	addr_start = (u64)mem;
 
+	// (TBD)
+	// If the segments are *not* contiguous, need we make them uncontiguous here too?
+	// In other words, do we expect exactly the same memory layout as specified in the ELF?
+	// (Currently this FOR loop doesn't behave like that and will suppress any blank page in the middle)
 	for (ph_i = 0, offset = 0; ph_i < ehdr->e_phnum; ph_i++) {
 		Elf64_Xword p_filesz = phdr[ph_i].p_filesz;
 		Elf64_Xword p_memsz = phdr[ph_i].p_memsz;


### PR DESCRIPTION
The current infrastructure fails to load certain Rust programs (e.g. my bizarre and awkward benchmarks).

- [x] Kernel side: some checks will throw `EINVAL`'s. Commented out.
- [ ] Kernel side: handle segments that are not contiguous
- [ ] Kernel side: perhaps we need larger type for some variables
- [ ] Rust side: avoid hitting the stack limit, especially `bpf_trace_printk`

---

An illustration of non-contiguous segments:

![image](https://user-images.githubusercontent.com/35722712/186391908-c9c3eeed-79e1-4505-affd-1da2faed293b.png)
