### PR TITLE
Runtime-dev

### DIFF
--- a/include/uapi/linux/bpf.h
+++ b/include/uapi/linux/bpf.h
@@ -1341,6 +1341,8 @@ union bpf_attr {
 			struct {
 				__u32		rustfd;		/* file descriptor of Rust Program */
 				__aligned_u64	map_offs;	/* offsets of map relocs */
+				__aligned_u64	got_off; /* offset of GOT section */
+				__aligned_u64	got_size; /* size of GOT section in bytes */
 				__u32		map_cnt;	/* length map reloc array */	
 			};
 			struct {

--- a/include/uapi/linux/bpf.h
+++ b/include/uapi/linux/bpf.h
@@ -1255,6 +1255,12 @@ struct bpf_stack_build_id {
 
 #define BPF_OBJ_NAME_LEN 16U
 
+struct iu_rela_dyn {
+	__u64	addr;
+	__u64	type;
+	__u64	value;
+};
+
 union bpf_attr {
 	struct { /* anonymous struct used by BPF_MAP_CREATE command */
 		__u32	map_type;	/* one of enum bpf_map_type */
@@ -1337,20 +1343,22 @@ union bpf_attr {
 			/* or valid module BTF object fd or 0 to attach to vmlinux */
 			__u32		attach_btf_obj_fd;
 		};
+		__u32		:32;		/* pad */
 		union {
 			struct {
-				__u32		rustfd;		/* file descriptor of Rust Program */
 				__aligned_u64	map_offs;	/* offsets of map relocs */
-				__aligned_u64	got_off; /* offset of GOT section */
-				__aligned_u64	got_size; /* size of GOT section in bytes */
+				__aligned_u64	got_off;	/* offset of GOT section */
+				__aligned_u64	got_size;	/* size of GOT section in bytes */
+				__aligned_u64	dyn_relas;	/* ptr to dynamic rela info */
+				__aligned_u64	nr_dyn_relas;	/* nr of dyn rela entries */
+				__u32		rustfd;		/* file descriptor of Rust Program */
 				__u32		map_cnt;	/* length map reloc array */	
 			};
 			struct {
-				__u32		base_prog_fd; /* fd of the base prog */
-				__aligned_u64	prog_offset; /* offset of prog in base prog */
+				__aligned_u64	prog_offset;	/* offset of prog in base */
+				__u32		base_prog_fd;	/* fd of the base prog */
 			};
 		};
-		__u32		:32;		/* pad */
 		__aligned_u64	fd_array;	/* array of FDs */
 	};
 

--- a/kernel/bpf/syscall.c
+++ b/kernel/bpf/syscall.c
@@ -3050,21 +3050,21 @@ static int bpf_prog_load_iu_base(union bpf_attr *attr, bpfptr_t uattr)
 		int idx;
 
 		if (attr->map_cnt >= MAX_USED_MAPS) {
-			//printk("attr->iu_maps_len >= MAX_USED_MAPS\n");
+			printk("attr->iu_maps_len >= MAX_USED_MAPS\n");
 			err = -EINVAL;
 			goto free_used_maps;
 		}
 
 		if (copy_from_bpfptr(map_offs, USER_BPFPTR((void *)(attr->map_offs)),
 							 sizeof(u64) * attr->map_cnt) != 0) {
-			//printk("copy_from_bpfptr() != 0\n");
+			printk("copy_from_bpfptr() != 0\n");
 			err = -EFAULT;
 			goto free_used_maps;
 		}
 
 		used_maps = kmalloc(sizeof(*used_maps) * attr->map_cnt, GFP_KERNEL);
 		if (!used_maps) {
-			//printk("!used_maps\n");
+			printk("!used_maps\n");
 			err = -ENOMEM;
 			goto free_used_maps;
 		}
@@ -3072,8 +3072,8 @@ static int bpf_prog_load_iu_base(union bpf_attr *attr, bpfptr_t uattr)
 		for (idx = 0; idx < attr->map_cnt; idx++) {
 			u64 *map_addr = (u64 *)(addr_start + map_offs[idx]);
 			struct bpf_map *curr = bpf_map_get(*map_addr);
-			//printk("map offset = 0x%lx\n", map_offs[idx]);
-			//printk("map addr = 0x%lx\n", *map_addr);
+			printk("map offset = 0x%lx\n", map_offs[idx]);
+			printk("map addr = 0x%lx\n", *map_addr);
 
 			if (IS_ERR(curr)) {
 				kfree(used_maps);
@@ -3086,6 +3086,26 @@ static int bpf_prog_load_iu_base(union bpf_attr *attr, bpfptr_t uattr)
 		}
 		prog->aux->used_maps = used_maps;
 		prog->aux->used_map_cnt = attr->map_cnt;
+	}
+
+	if (attr->got_size) {
+		u64 got_nr_syms;
+		u64 *got;
+		int i = 0;
+
+		if (attr->got_size & 0x7) {
+			err = -EINVAL;
+			goto free_used_maps;
+		}
+
+		got_nr_syms = attr->got_size >> 3;
+		got = (u64 *)(addr_start + attr->got_off);
+
+		for (i = 0; i < got_nr_syms; i++) {
+			printk("got[%d] = 0x%lx\n", i, got[i]);
+			got[i] += addr_start;
+			printk("got[%d] = 0x%lx\n", i, got[i]);
+		}
 	}
 
 	err = bpf_prog_alloc_id(prog);

--- a/kernel/bpf/syscall.c
+++ b/kernel/bpf/syscall.c
@@ -3108,6 +3108,47 @@ static int bpf_prog_load_iu_base(union bpf_attr *attr, bpfptr_t uattr)
 		}
 	}
 
+	if (attr->nr_dyn_relas) {
+		int i = 0;
+		u64 relas_size = sizeof(struct iu_rela_dyn) * attr->nr_dyn_relas;
+		struct iu_rela_dyn *relas = kmalloc(relas_size, GFP_KERNEL);
+
+		if (copy_from_bpfptr(relas,
+							 make_bpfptr(attr->dyn_relas, uattr.is_kernel),
+							 relas_size) != 0) {
+			err = -EFAULT;
+			kfree(relas);
+			goto free_used_maps;
+		}
+
+		for (i = 0; i < attr->nr_dyn_relas; i++) {
+			u64 *abs_addr;
+			err = -EINVAL;
+
+			if (relas[i].type != R_X86_64_RELATIVE) {
+				kfree(relas);
+				goto free_used_maps;
+			}
+
+			printk("relas[%d]: addr=0x%lx, value=0x%lx\n", i, relas[i].addr,
+					relas[i].value);
+			abs_addr = (u64 *)(addr_start + relas[i].addr);
+			printk("Original value at addr 0x%lx is 0x%lx\n", relas[i].addr,
+					*abs_addr);
+			if (*abs_addr != relas[i].value) {
+				kfree(relas);
+				goto free_used_maps;
+			}
+
+			*abs_addr += addr_start;
+
+			printk("Updated value at addr 0x%lx is 0x%lx\n", relas[i].addr,
+					*abs_addr);
+		}
+
+		kfree(relas);
+	}
+
 	err = bpf_prog_alloc_id(prog);
 	if (err)
 		goto free_used_maps;


### PR DESCRIPTION
### Patch GOT at load time
When we compile the rust programs with PIE, the compiler creates the
Global Offset Table (GOT) to put the address of the extern variables.
The GOT is supposed to be fixed at program load time by the dynamic
loader. However, we do not have a dynamic loader and therefore, the GOT
entries are un-patched and contain absolute addresses. This causes
problem when the program is triggered in the kernel -- the use of
absolute address will cause the code going to non-existing pages.

Add a new GOT fix step when the base program is loaded.

Signed-off-by: Jinghao Jia <jinghao7@illinois.edu>