### PR TITLE
scripts: apply proper pahole fix

### DIFF
--- a/scripts/link-vmlinux.sh
+++ b/scripts/link-vmlinux.sh
@@ -225,7 +225,10 @@ gen_btf()
 		extra_paholeopt="${extra_paholeopt} --skip_encoding_btf_vars"
 	fi
 	if [ "${pahole_ver}" -ge "121" ]; then
-		extra_paholeopt="${extra_paholeopt} --btf_gen_floats --skip_encoding_btf_enum64"
+		extra_paholeopt="${extra_paholeopt} --btf_gen_floats"
+	fi
+	if [ "${pahole_ver}" -ge "124" ]; then
+		extra_paholeopt="${extra_paholeopt} --skip_encoding_btf_enum64"
 	fi
 
 	info "BTF" ${2}


### PR DESCRIPTION
current one isn't backwards compatible and will cause issues upon linking, primarily


`pahole: unrecognized option '--skip _encoding_btf_enum64`
