### PR TITLE
Support for rust panic handling and stack unwinding

### DIFF
--- a/arch/x86/net/Makefile
+++ b/arch/x86/net/Makefile
@@ -8,3 +8,6 @@ ifeq ($(CONFIG_X86_32),y)
 else
         obj-$(CONFIG_BPF_JIT) += bpf_jit_comp.o
 endif
+
+obj-y += iu_unwind.o
+obj-y += iu_unwind_$(BITS).o

--- a/arch/x86/net/iu_unwind.c
+++ b/arch/x86/net/iu_unwind.c
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#include <linux/bug.h>
+#include <linux/compiler_types.h>
+#include <linux/percpu.h>
+#include <linux/printk.h>
+
+DEFINE_PER_CPU(unsigned long, iu_sp);
+DEFINE_PER_CPU(unsigned long, iu_fp);
+
+__nocfi noinline void notrace __noreturn iu_landingpad(char *msg)
+{
+	/* Report error */
+	pr_warn("Panic from inner-unikernel prog: %s\n", msg);
+	dump_stack();
+
+	/* Jump to trampoline */
+	asm volatile(
+		"jmp iu_panic_trampoline"
+	);
+
+	/* Unreachable, noreturn */
+	BUG();
+}

--- a/arch/x86/net/iu_unwind_64.S
+++ b/arch/x86/net/iu_unwind_64.S
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#include <linux/linkage.h>
+#include <asm/errno.h>
+#include <asm/percpu.h>
+
+	.code64
+	.section .text, "ax"
+
+/* Dispatcher func for inner-unikernel */
+SYM_FUNC_START(iu_dispatcher_func)
+	/* save rsp and rbp */
+	movq %rsp, PER_CPU_VAR(iu_sp)
+	movq %rbp, PER_CPU_VAR(iu_fp)
+
+	/* invoke bpf func */
+	call *%rdx
+
+/* Exit path */
+SYM_INNER_LABEL(iu_exit, SYM_L_LOCAL)
+	RET
+
+/* Rust panic path */
+SYM_INNER_LABEL(iu_panic_trampoline, SYM_L_GLOBAL)
+	/* reset rsp and rbp based on saved value */
+	movq PER_CPU_VAR(iu_sp), %rsp
+	movq PER_CPU_VAR(iu_fp), %rbp
+
+	/* Give a EINVAL as return value */
+	movq $(-EINVAL), %rax
+
+	/* Exit */
+	jmp iu_exit
+
+SYM_FUNC_END(iu_dispatcher_func)

--- a/include/linux/bpf.h
+++ b/include/linux/bpf.h
@@ -718,6 +718,13 @@ static __always_inline __nocfi unsigned int bpf_dispatcher_nop_func(
     //    printk(KERN_WARNING "DJW CALLING bpf_func at %p %d\n", bpf_func, __LINE__);
 	return bpf_func(ctx, insnsi);
 }
+
+extern asmlinkage unsigned int iu_dispatcher_func(
+	const void *ctx,
+	const struct bpf_insn *insnsi,
+	unsigned int (*bpf_func)(const void *,
+				 const struct bpf_insn *));
+
 #ifdef CONFIG_BPF_JIT
 int bpf_trampoline_link_prog(struct bpf_prog *prog, struct bpf_trampoline *tr);
 int bpf_trampoline_unlink_prog(struct bpf_prog *prog, struct bpf_trampoline *tr);

--- a/include/linux/filter.h
+++ b/include/linux/filter.h
@@ -643,7 +643,9 @@ static __always_inline u32 __bpf_prog_run(const struct bpf_prog *prog,
 
 static __always_inline u32 bpf_prog_run(const struct bpf_prog *prog, const void *ctx)
 {
-	return __bpf_prog_run(prog, ctx, bpf_dispatcher_nop_func);
+	return __bpf_prog_run(prog, ctx,
+			      prog->no_bpf ? iu_dispatcher_func :
+					     bpf_dispatcher_nop_func);
 }
 
 /*


### PR DESCRIPTION
### How it works:

Taken from the commit message:

Add a new `iu_dispatcher_func` to dispatch inner-unikernel programs so
that rust panics can be handled. The dispatch have a prototype of:

```C
extern asmlinkage unsigned int iu_dispatcher_func(
        const void *ctx,
        const struct bpf_insn *insnsi,
        unsigned int (*bpf_func)(const void *,
                                 const struct bpf_insn *));
```

which shares the same signature as `bpf_dispatcher_nop_func` but differs
in linkage, as it is implemented directly in assembly.

The function will save the stack pointer and frame pointer to designated
per-cpu variables before calling into the program.

If the execution is successful (i.e. no exceptions), the function will
just return normally.

```
   +-----------------------+
   | iu_dispatcher_func:   |
   | movq %rsp %gs:iu_sp   |
   | movq %rbp %gs:iu_fp   |                +-----------+
   | call *%rdx            |--------------->| iu_prog1: |
   |                       |                | ...       |
   | iu_exit:              |<---------------| ret       |
   | ret                   |                +-----------+
   | ...                   |
   +-----------------------+
```

Under exceptional cases (where a rust panic is fired), `rust_begin_unwind`
(i.e. panic handler) will transfer the control flow to the `iu_landingpad`
function, which, after dumping some information to the kernel ring buffer,
will issue a direct jump to `iu_panic_trampoline`, a global label in the
middle of `iu_dispatcher_func`. The trampoline code restores the old stack
pointer and frame pointer value, effectively unwinding the stack.  It
then sets a return value of `-EINVAL` and jumps to `iu_exit` to return from
`iu_dispatcher_func`.

```
         +-----------------------+
         | iu_dispatcher_func:   |
         | movq %rsp, %gs:iu_sp  |
         | movq %rbp, %gs:iu_fp  |                +-----------+
         | call *%rdx            |--------------->| iu_prog1: |
         |                       |         +------| ...       |
   +---->| iu_exit:              |         |      | ret       |
   |     | ret                   |         |      +-----------+
   |     |                       |         |
   |     | iu_panic_trampoline:  |<-----+  | panic!()
   |     | movq %gs:iu_sp, %rsp  |      |  |
   |     | movq %gs:iu_fp, %rbp  |      |  |      +-------------------------+
   |     | movq $(-EINVAL), %rax |      |  +----->| iu_landingpad:          |
   +-----| jmp iu_exit           |      |         | ...                     |
         +-----------------------+      +---------| jmp iu_panic_trampoline |
                                                  +-------------------------+
```

This right now only works for program invocations where
`bpf_dispatcher_nop_func` is used originally. It does cover all tracing
programs (i.e. these invoked via `trace_call_bpf`). Other program types
(e.g. XDP) are not supported.

For further information please refer to the actual commits.